### PR TITLE
bump save-image to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "ndarray": "^1.0.14",
     "pngparse-sync": "^1.0.1",
-    "save-pixels": "^1.0.0",
+    "save-pixels": "^2.0.0",
     "get-pixels": "^3.0.1",
     "concat-stream": "^1.4.5"
   },


### PR DESCRIPTION
fixes https://github.com/mikolalysenko/ndpack-image/issues/3